### PR TITLE
Add 2 twig functions, maybe_encore_entry_...css

### DIFF
--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -14,6 +14,7 @@ use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException;
 
 final class EntryFilesTwigExtension extends AbstractExtension
 {
@@ -31,6 +32,8 @@ final class EntryFilesTwigExtension extends AbstractExtension
             new TwigFunction('encore_entry_css_files', [$this, 'getWebpackCssFiles']),
             new TwigFunction('encore_entry_script_tags', [$this, 'renderWebpackScriptTags'], ['is_safe' => ['html']]),
             new TwigFunction('encore_entry_link_tags', [$this, 'renderWebpackLinkTags'], ['is_safe' => ['html']]),
+            new TwigFunction('maybe_encore_entry_script_tags', [$this, 'maybeRenderWebpackScriptTags'], ['is_safe' => ['html']]),
+            new TwigFunction('maybe_encore_entry_link_tags', [$this, 'maybeRenderWebpackLinkTags'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -57,7 +60,29 @@ final class EntryFilesTwigExtension extends AbstractExtension
         return $this->getTagRenderer()
             ->renderWebpackLinkTags($entryName, $packageName, $entrypointName);
     }
+    
+    public function maybeRenderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
+    {
+        try {         
+            return $this->getTagRenderer()
+                ->renderWebpackScriptTags($entryName, $packageName, $entrypointName);
+        }
+        catch (EntrypointNotFoundException $e) {
+            return '';
+        }
+    }
 
+    public function maybeRenderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
+    {
+        try { 
+            return $this->getTagRenderer()
+                ->renderWebpackLinkTags($entryName, $packageName, $entrypointName);
+        }
+        catch (EntrypointNotFoundException $e) {
+            return '';
+        }
+    }
+    
     private function getEntrypointLookup(string $entrypointName): EntrypointLookupInterface
     {
         return $this->container->get('webpack_encore.entrypoint_lookup_collection')


### PR DESCRIPTION
These 2 new functions mirror the regular one, but they don't fail if the asset is not found. Usefull if you're dynamically building your assets names, and want to load somes assets, but discard the inexistant ones